### PR TITLE
Upgrade cudarc to 0.16.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "cudarc"
-version = "0.13.9"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486c221362668c63a1636cfa51463b09574433b39029326cff40864b3ba12b6e"
+checksum = "f9574894139a982bf26fbb44473a9d416c015e779c51ef0fbc0789f1a1c17b25"
 dependencies = [
  "half",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,51 @@ num-traits = { version = "0.2.14", default-features = false, features = [
     "libm",
 ], optional = true }
 zerocopy = { version = "0.6.0", default-features = false, optional = true }
-rand = { version = "0.9.0", default-features = false, features = ["std", "std_rng", "thread_rng"], optional = true }
-rand_distr = { version = "0.5.0", default-features = false, optional = true }
+rand = { version = "0.9.0", default-features = false, features = [
+    "std",
+    "std_rng",
+    "thread_rng",
+], optional = true }
+rand_distr = { version = "0.5.1", default-features = false, optional = true }
 rkyv = { version = "0.7", optional = true }
-cudarc = { version = "0.13.3", features = ["std", "cublas", "cublaslt", "curand", "driver", "nvrtc", "f16", "cuda-version-from-build-system", "dynamic-linking"], default-features=false, optional = true }
-mistralrs_cudarc_fork = { version = "0.12.1", features = ["std", "cublas", "cublaslt", "curand", "driver", "nvrtc", "f16", "cuda-version-from-build-system", "dynamic-linking"], default-features=false, optional = true }
+cudarc = { version = "0.16.3", features = [
+    "std",
+    "cublas",
+    "cublaslt",
+    "curand",
+    "driver",
+    "nvrtc",
+    "f16",
+    "cuda-version-from-build-system",
+    "dynamic-linking",
+], default-features = false, optional = true }
+mistralrs_cudarc_fork = { version = "0.12.1", features = [
+    "std",
+    "cublas",
+    "cublaslt",
+    "curand",
+    "driver",
+    "nvrtc",
+    "f16",
+    "cuda-version-from-build-system",
+    "dynamic-linking",
+], default-features = false, optional = true }
 
 [features]
 default = ["std"]
 std = []
 cuda = ["dep:cudarc"]
 mistralrs_cudarc_fork = ["dep:mistralrs_cudarc_fork"]
-all = ["std", "num-traits", "rand_distr", "bytemuck", "zerocopy", "rkyv", "serde", "cuda"]
+all = [
+    "std",
+    "num-traits",
+    "rand_distr",
+    "bytemuck",
+    "zerocopy",
+    "rkyv",
+    "serde",
+    "cuda",
+]
 num-traits = ["dep:num-traits"]
 rand_distr = ["dep:rand_distr", "dep:rand", "std"]
 bytemuck = ["dep:bytemuck"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1565,22 +1565,14 @@ from_t!(F8E4M3);
 from_t!(F8E5M2);
 
 #[cfg(feature = "cuda")]
-unsafe impl cudarc::driver::DeviceRepr for F8E4M3 {
-    fn as_kernel_param(&self) -> *mut std::ffi::c_void {
-        use std::ptr::addr_of;
-        addr_of!(self.0) as *const u8 as *mut _
-    }
-}
+unsafe impl cudarc::driver::DeviceRepr for F8E4M3 {}
+
 #[cfg(feature = "cuda")]
 unsafe impl cudarc::driver::ValidAsZeroBits for F8E4M3 {}
 
 #[cfg(feature = "cuda")]
-unsafe impl cudarc::driver::safe::DeviceRepr for F8E5M2 {
-    fn as_kernel_param(&self) -> *mut std::ffi::c_void {
-        use std::ptr::addr_of;
-        addr_of!(self.0) as *const u8 as *mut _
-    }
-}
+unsafe impl cudarc::driver::safe::DeviceRepr for F8E5M2 {}
+
 #[cfg(feature = "cuda")]
 unsafe impl cudarc::driver::ValidAsZeroBits for F8E5M2 {}
 


### PR DESCRIPTION
Long term, probably want to add the `DeviceRepr` impls to the cudarc crate just like `half` does? 

Upping cudarc to 0.16 so it's compatible with candle. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency versions for improved compatibility and maintenance.
  - Reformatted feature lists in configuration for better readability.

- **Refactor**
  - Simplified internal trait implementations for certain types, relying on default behavior. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->